### PR TITLE
feat: added macOS service management with CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 ### Disclaimer: Test with caution! This is a pre-alpha version! Macs on ARM ONLY!!!
 
+### Features
+
+- **Automatic keyboard layout switching** based on active application
+- **Service management** - install as background service with auto-start
+- **Log rotation** - automatic log management to prevent disk space issues
+- **CLI interface** with commands: install, uninstall, status, logs
+
 ## Why?
 
 Anyone who uses more than one keyboard layout daily knows the struggle: the person who designed the layout switching flow for macOS probably only uses one language and doesn't rely on their own feature. Otherwise, I can't explain why it's still so cumbersome.
@@ -16,50 +23,84 @@ So, I built this tool to save my time and nerves. I originally built it for myse
 
 When you first run Language Handler, it creates a configuration file. This config file is simple: `"%APP_NAME%": "%LANGUAGE_CODE%"`.
 
-* **`%APP_NAME%`**: The name of the application (e.g., "Terminal", "Google Chrome").
-* **`%LANGUAGE_CODE%`**: A short code for your desired layout.
+- **`%APP_NAME%`**: The name of the application (e.g., "Terminal", "Google Chrome").
+- **`%LANGUAGE_CODE%`**: A short code for your desired layout.
 
 **Currently supported language codes (for the config file):**
-* `EN` (English/US)
-* `RU` (Russian)
-* `CN` (Chinese - Simplified Pinyin)
-* `HI` (Hindi - Devanagari QWERTY)
+
+- `EN` (English/US)
+- `RU` (Russian)
+- `CN` (Chinese - Simplified Pinyin)
+- `HI` (Hindi - Devanagari QWERTY)
 
 **Not sure about the application name?** Check the tool's log output (the Terminal window it opens). When you focus on an application window, its name will be shown there.
 
 Once everything is set up, Language Handler will automatically change your keyboard layout when you focus on an application listed in your config file.
+
+## CLI Commands
+
+```bash
+# Install as background service (auto-start on login)
+./language-handler install
+
+# Check service status
+./language-handler status
+
+# View logs
+./language-handler logs
+
+# Uninstall service
+./language-handler uninstall
+
+# Show help
+./language-handler help
+```
 
 ## How to Use
 
 1.  **Download the Binary**
 
     Run this command in your Terminal:
+
     ```
     curl -LO https://github.com/rostislavnagimov/language-handler/releases/download/v0.0.1/language-handler-macos-arm.zip
     ```
-    The `.zip` archive will be downloaded to your current working directory.
-    *Note: If you download the file through a web browser, macOS might warn you about an "Unknown developer" or even prevent you from running the tool. Using `curl` as shown above usually avoids these issues.*
 
-3.  **Unzip and Run**
-    * Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
-    * Run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory).
+    The `.zip` archive will be downloaded to your current working directory.
+    _Note: If you download the file through a web browser, macOS might warn you about an "Unknown developer" or even prevent you from running the tool. Using `curl` as shown above usually avoids these issues._
+
+2.  **Unzip and Run**
+
+        - Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
+
+        - **Install as service** (recommended):
+
+    ```bash
+        ./language-handler install
+    ```
+
+    - **Or run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory):**
 
     You will see a new Terminal window appear with logs from the tool. **The current version requires this Terminal window to remain open while the tool is working.** You can hide or minimize this window, but please don't close it if you want the tool to keep running.
 
     On the first launch, a `config.json` file will be created with default rules. This is a starting point, but you'll likely want to customize it.
 
     **Important:** To apply any changes made to the `config.json` file, you need to:
+
     1.  Stop the currently running version of Language Handler (by closing its Terminal window or pressing `Ctrl+C` in that window).
     2.  Run it again.
 
-4.  **Edit the Configuration File**
+3.  **Edit the Configuration File**
     To edit your `config.json` file, copy and paste this command into your Terminal:
+
     ```
     open "$HOME/Library/Application Support/language-handler/config.json"
     ```
+
     This will open the config file in your default text editor. After you've set your rules, save the changes and restart Language Handler as described above.
 
     **Example `config.json`:**
+
     ```json
     {
       "Terminal": "EN",
@@ -72,6 +113,7 @@ Once everything is set up, Language Handler will automatically change your keybo
 ## Building from Source (Optional)
 
 If you prefer to build from source:
+
 1.  Ensure you have Rust installed: [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install)
 2.  Clone this repository.
 3.  Navigate to the project directory and run `cargo build --release`.
@@ -79,7 +121,7 @@ If you prefer to build from source:
 
 ## Contributing
 
-First you can donate me on Solana : ```pG9TZUjpmtbbvMU8MjKpjbdvBcXLcHWQsyM2Qqq4BpB```
+First you can donate me on Solana : `pG9TZUjpmtbbvMU8MjKpjbdvBcXLcHWQsyM2Qqq4BpB`
 
 Second you can offer me a job: [resume with all the contact data](https://drive.google.com/file/d/1o8lOwgBqpbccm-I-g5rkBLs4DM9qTqD7/view)
 
@@ -89,4 +131,8 @@ Also you can rate the repo, I will really appreciate that.
 
 ## License
 
- Working under my personal 'I Don't Care' licence, free to use for everyone, go ahead.
+Working under my personal 'I Don't Care' licence, free to use for everyone, go ahead.
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 - **Automatic keyboard layout switching** based on active application
 - **Service management** - install as background service with auto-start
-- **Log rotation** - automatic log management to prevent disk space issues
 - **CLI interface** with commands: install, uninstall, status, logs
 
 ## Why?
@@ -71,15 +70,11 @@ Once everything is set up, Language Handler will automatically change your keybo
 
 2.  **Unzip and Run**
 
-        - Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
+        * Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
 
-        - **Install as service** (recommended):
+        * Install as service (recommended):
 
-    ```bash
-        ./language-handler install
-    ```
-
-    - **Or run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory):**
+        * Or run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory):
 
     You will see a new Terminal window appear with logs from the tool. **The current version requires this Terminal window to remain open while the tool is working.** You can hide or minimize this window, but please don't close it if you want the tool to keep running.
 

--- a/README.md
+++ b/README.md
@@ -70,40 +70,57 @@ Once everything is set up, Language Handler will automatically change your keybo
 
 2.  **Unzip and Run**
 
-        * Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
+- Unzip the archive (e.g., by double-clicking it in Finder, or using `unzip language-handler-macos-arm.zip` in Terminal).
 
-        * Install as service (recommended):
+- Run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory).
 
-        * Or run the `language-handler` binary (e.g., by double-clicking it or running `./language-handler` in Terminal if you are in the same directory):
+- **Option A: Install as service (recommended)**:
 
-    You will see a new Terminal window appear with logs from the tool. **The current version requires this Terminal window to remain open while the tool is working.** You can hide or minimize this window, but please don't close it if you want the tool to keep running.
+  ```bash
+  ./language-handler install
+  ```
 
-    On the first launch, a `config.json` file will be created with default rules. This is a starting point, but you'll likely want to customize it.
+  When installed as a service, the app runs automatically in the background. You can close the terminal - the service will continue running and start automatically on login.
 
-    **Important:** To apply any changes made to the `config.json` file, you need to:
+- **Option B: Run manually**:
 
-    1.  Stop the currently running version of Language Handler (by closing its Terminal window or pressing `Ctrl+C` in that window).
-    2.  Run it again.
+  ```bash
+  ./language-handler
+  ```
+
+  When running manually, **you must keep the terminal window open**. The app will stop if you close the terminal or press Ctrl+C.
+
+On the first launch, a `config.json` file will be created with default rules. This is a starting point, but you'll likely want to customize it.
+
+**Important:** To apply any changes made to the `config.json` file, you need to:
+
+1.  Stop the currently running version of Language Handler (by closing its Terminal window or pressing `Ctrl+C` in that window).
+2.  Run it again.
 
 3.  **Edit the Configuration File**
     To edit your `config.json` file, copy and paste this command into your Terminal:
 
-    ```
-    open "$HOME/Library/Application Support/language-handler/config.json"
-    ```
+```
 
-    This will open the config file in your default text editor. After you've set your rules, save the changes and restart Language Handler as described above.
+open "$HOME/Library/Application Support/language-handler/config.json"
 
-    **Example `config.json`:**
+```
 
-    ```json
-    {
-      "Terminal": "EN",
-      "iTerm2": "EN",
-      "Google Chrome": "EN",
-      "Telergam": "RU"
-    }
-    ```
+This will open the config file in your default text editor. After you've set your rules, save the changes and restart Language Handler:
+
+- **If running as service**: `./language-handler uninstall` then `./language-handler install`
+- **If running manually**: Stop the app (Ctrl+C) and run `./language-handler` again
+
+**Example `config.json`:**
+
+```json
+{
+  "Terminal": "EN",
+  "iTerm2": "EN",
+  "Google Chrome": "EN",
+  "Telergam": "RU"
+}
+```
 
 ## Building from Source (Optional)
 
@@ -127,7 +144,3 @@ Also you can rate the repo, I will really appreciate that.
 ## License
 
 Working under my personal 'I Don't Care' licence, free to use for everyone, go ahead.
-
-```
-
-```

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,4 +2,5 @@ pub mod config;
 pub mod macos_api;
 pub mod monitor;
 pub mod observer;
+pub mod service;
 pub mod switcher;

--- a/src/core/service.rs
+++ b/src/core/service.rs
@@ -1,0 +1,284 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn get_plist_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/default".to_string());
+    Path::new(&home)
+        .join("Library")
+        .join("LaunchAgents")
+        .join("com.language-handler.plist")
+}
+
+pub fn get_binary_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let current_exe = std::env::current_exe()?;
+    Ok(current_exe)
+}
+
+fn get_log_directory() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/default".to_string());
+    Path::new(&home)
+        .join("Library")
+        .join("Logs")
+        .join("language-handler")
+}
+
+fn create_plist_content(binary_path: &str) -> String {
+    let log_dir = get_log_directory();
+    let stdout_log = log_dir.join("language-handler.log");
+    let stderr_log = log_dir.join("language-handler.error.log");
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.language-handler</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{}</string>
+    <key>StandardErrorPath</key>
+    <string>{}</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>256</integer>
+    </dict>
+</dict>
+</plist>"#,
+        binary_path,
+        stdout_log.to_string_lossy(),
+        stderr_log.to_string_lossy()
+    )
+}
+
+pub fn install_service() -> Result<(), Box<dyn std::error::Error>> {
+    let binary_path = get_binary_path()?;
+    let plist_path = get_plist_path();
+    let log_dir = get_log_directory();
+
+    if let Some(parent) = plist_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::create_dir_all(&log_dir)?;
+
+    let plist_content = create_plist_content(binary_path.to_str().unwrap());
+    fs::write(&plist_path, plist_content)?;
+
+    let output = Command::new("launchctl")
+        .args(&["load", plist_path.to_str().unwrap()])
+        .output()?;
+
+    if output.status.success() {
+        println!("✅ Service installed successfully!");
+        println!("Binary path: {}", binary_path.display());
+        println!("Plist path: {}", plist_path.display());
+        println!("Logs directory: {}", log_dir.display());
+        println!("\nThe service will start automatically on next login.");
+        println!("To start it now, run: launchctl start com.language-handler");
+
+        install_log_rotation()?;
+    } else {
+        let error = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to load service: {}", error).into());
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_service() -> Result<(), Box<dyn std::error::Error>> {
+    let plist_path = get_plist_path();
+
+    if !plist_path.exists() {
+        println!("Service is not installed.");
+        return Ok(());
+    }
+
+    let output = Command::new("launchctl")
+        .args(&["unload", plist_path.to_str().unwrap()])
+        .output()?;
+
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        println!("Warning: Failed to unload service: {}", error);
+    }
+
+    fs::remove_file(&plist_path)?;
+
+    println!("✅ Service uninstalled successfully!");
+    Ok(())
+}
+
+pub fn check_service_status() -> Result<(), Box<dyn std::error::Error>> {
+    let plist_path = get_plist_path();
+
+    if !plist_path.exists() {
+        println!("❌ Service is not installed.");
+        return Ok(());
+    }
+
+    let output = Command::new("launchctl")
+        .args(&["list", "com.language-handler"])
+        .output()?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() {
+            println!("📋 Service is installed but not running.");
+        } else {
+            println!("✅ Service is installed and running.");
+            println!("Details:\n{}", stdout);
+        }
+    } else {
+        println!("📋 Service is installed but not loaded.");
+    }
+
+    println!("Plist location: {}", plist_path.display());
+    Ok(())
+}
+
+fn install_log_rotation() -> Result<(), Box<dyn std::error::Error>> {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/default".to_string());
+    let log_rotation_plist = Path::new(&home)
+        .join("Library")
+        .join("LaunchAgents")
+        .join("com.language-handler.logrotate.plist");
+
+    let log_dir = get_log_directory();
+    let script_content = format!(
+        r#"#!/bin/bash
+
+LOG_DIR="{}"
+MAX_SIZE=10485760 # 10MB in bytes
+MAX_DAYS=7
+
+rotate_log() {{
+    local logfile="$1"
+
+    if [[ -f "$logfile" ]]; then
+        local size=$(stat -f%z "$logfile" 2>/dev/null || echo 0)
+
+        if [[ $size -gt $MAX_SIZE ]]; then
+            echo "$(date): Rotating $logfile (size: $size bytes)"
+
+            tail -n 1000 "$logfile" > "${{logfile}}.tmp"
+            mv "${{logfile}}.tmp" "$logfile"
+
+            echo "$(date): Log rotated, kept last 1000 lines" >> "$logfile"
+        fi
+    fi
+}}
+
+find "$LOG_DIR" -name "*.log.*" -mtime +$MAX_DAYS -delete 2>/dev/null
+
+rotate_log "$LOG_DIR/language-handler.log"
+rotate_log "$LOG_DIR/language-handler.error.log"
+
+exit 0
+"#,
+        log_dir.to_string_lossy()
+    );
+
+    let script_path = log_dir.join("rotate_logs.sh");
+    fs::write(&script_path, script_content)?;
+
+    Command::new("chmod")
+        .args(&["+x", script_path.to_str().unwrap()])
+        .output()?;
+
+    let rotation_plist_content = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.language-handler.logrotate</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{}</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{}/rotation.log</string>
+    <key>StandardErrorPath</key>
+    <string>{}/rotation.error.log</string>
+</dict>
+</plist>"#,
+        script_path.to_string_lossy(),
+        log_dir.to_string_lossy(),
+        log_dir.to_string_lossy()
+    );
+
+    fs::write(&log_rotation_plist, rotation_plist_content)?;
+
+    let output = Command::new("launchctl")
+        .args(&["load", log_rotation_plist.to_str().unwrap()])
+        .output()?;
+
+    if output.status.success() {
+        println!("📋 Log rotation task installed (runs daily at 2:00 AM)");
+    } else {
+        println!("⚠️  Warning: Could not install log rotation task");
+    }
+
+    Ok(())
+}
+
+pub fn show_logs() -> Result<(), Box<dyn std::error::Error>> {
+    let log_dir = get_log_directory();
+    let main_log = log_dir.join("language-handler.log");
+    let error_log = log_dir.join("language-handler.error.log");
+
+    println!("📂 Logs location: {}", log_dir.display());
+    println!();
+
+    if main_log.exists() {
+        if let Ok(metadata) = fs::metadata(&main_log) {
+            println!("📄 Main log: {} ({:.2} MB)",
+                main_log.display(),
+                metadata.len() as f64 / 1024.0 / 1024.0
+            );
+        }
+
+        println!("Last 20 lines:");
+        let output = Command::new("tail")
+            .args(&["-n", "20", main_log.to_str().unwrap()])
+            .output()?;
+
+        if output.status.success() {
+            println!("{}", String::from_utf8_lossy(&output.stdout));
+        }
+    }
+
+    if error_log.exists() {
+        if let Ok(metadata) = fs::metadata(&error_log) {
+            println!("🚨 Error log: {} ({:.2} MB)",
+                error_log.display(),
+                metadata.len() as f64 / 1024.0 / 1024.0
+            );
+        }
+    }
+
+    println!("\n💡 Commands:");
+    println!("  View logs: tail -f {}", main_log.to_string_lossy());
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ use cocoa::foundation::NSAutoreleasePool;
 
 pub mod core;
 
+// Re-export service functions for convenience
+pub use core::service::{install_service, uninstall_service, check_service_status};
+
 pub(crate) mod state {
     use std::collections::HashMap;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,72 @@
+use language_handler::core::service;
 use language_handler::run;
+use std::env;
+
+fn print_help() {
+    println!("Language Handler - Automatic keyboard layout switcher for macOS");
+    println!();
+    println!("USAGE:");
+    println!("    language-handler [COMMAND]");
+    println!();
+    println!("COMMANDS:");
+    println!("    run         Run the language handler (default)");
+    println!("    install     Install as a system service (auto-start on login)");
+    println!("    uninstall   Remove the system service");
+    println!("    status      Check service installation status");
+    println!("    logs        Show recent logs and log file locations");
+    println!("    help        Show this help message");
+    println!();
+    println!("EXAMPLES:");
+    println!("    language-handler                  # Run normally");
+    println!("    language-handler install          # Install as service");
+    println!("    language-handler status           # Check if service is installed");
+    println!("    language-handler logs             # View recent logs");
+}
 
 fn main() {
-    run();
+    let args: Vec<String> = env::args().collect();
+
+    let command = if args.len() > 1 {
+        args[1].as_str()
+    } else {
+        "run"
+    };
+
+    match command {
+        "install" => {
+            if let Err(e) = service::install_service() {
+                eprintln!("Error installing service: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "uninstall" => {
+            if let Err(e) = service::uninstall_service() {
+                eprintln!("Error uninstalling service: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "status" => {
+            if let Err(e) = service::check_service_status() {
+                eprintln!("Error checking service status: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "logs" => {
+            if let Err(e) = service::show_logs() {
+                eprintln!("Error showing logs: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "help" | "--help" | "-h" => {
+            print_help();
+        },
+        "run" => {
+            run();
+        },
+        _ => {
+            eprintln!("Unknown command: {}", command);
+            eprintln!("Use 'language-handler help' for usage information.");
+            std::process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
feat: add macOS service management with CLI commands

- Add service module with install/uninstall/status/logs functionality
- Implement launchd plist generation and log rotation
- Add CLI interface with install, uninstall, status, logs, help commands
- Integrated service functions into main application structure